### PR TITLE
Decode TOML floats as Go int when requested

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -53,7 +53,12 @@ func (i *Integer) Source() string {
 }
 
 func (i *Integer) Int() (int64, error) {
-	return strconv.ParseInt(i.Value, 10, 64)
+	intValue, err := strconv.ParseInt(i.Value, 10, 64)
+	if err == nil {
+		return intValue, nil
+	}
+	floatValue, err := strconv.ParseFloat(i.Value, 64)
+	return int64(floatValue), err
 }
 
 type Float struct {

--- a/decode.go
+++ b/decode.go
@@ -304,8 +304,12 @@ func setFloat(fv reflect.Value, v *ast.Float) error {
 		fv.SetFloat(f)
 	case reflect.Interface:
 		fv.Set(reflect.ValueOf(f))
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		fv.SetInt(int64(f))
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		fv.SetUint(uint64(f))
 	default:
-		return fmt.Errorf("`%v' is not float32 or float64", fv.Type())
+		return fmt.Errorf("`%v' is not float32 or float64 current kind is %v", fv.Type(), fv.Kind())
 	}
 	return nil
 }
@@ -508,7 +512,7 @@ func (p *toml) setArrayTable(t *ast.Table, buf []rune, begin, end int) {
 	}
 	last := names[len(names)-1]
 	tbl := &ast.Table{
-		Position: ast.Position{begin, end},
+		Position: ast.Position{Begin: begin, End: end},
 		Line:     p.line,
 		Name:     last,
 		Type:     ast.TableTypeArray,

--- a/decode_test.go
+++ b/decode_test.go
@@ -459,7 +459,7 @@ func TestUnmarshal_WithFloat(t *testing.T) {
 		{`floatval = -10.2E5`, nil, &testStruct{}, &testStruct{-10.2e5}},
 		{`floatval = 5e+22`, nil, &testStruct{}, &testStruct{5e+22}},
 		{`floatval = 1e6`, nil, &testStruct{}, &testStruct{1e6}},
-		{`floatval = -2E-2`, nil, &testStruct{}, &testStruct{-2E-2}},
+		{`floatval = -2E-2`, nil, &testStruct{}, &testStruct{-2e-2}},
 		{`floatval = 6.626e-34`, nil, &testStruct{}, &testStruct{6.626e-34}},
 		{`floatval = 9_224_617.445_991_228_313`, nil, &testStruct{}, &testStruct{9224617.445991228313}},
 		{`floatval = 1e1_00`, nil, &testStruct{}, &testStruct{1e100}},

--- a/encode_test.go
+++ b/encode_test.go
@@ -306,7 +306,7 @@ name="plantain"
 		actual = dest
 		expect = v.v
 		if !reflect.DeepEqual(actual, expect) {
-			t.Errorf(`Unmarshal after Marshal => %#v; want %#v`, v, actual, expect)
+			t.Errorf(`Unmarshal(%#v) after Marshal => %#v; want %#v`, v, actual, expect)
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/influxdata/toml
+
+go 1.13
+
+require github.com/naoina/go-stringutil v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/naoina/go-stringutil v0.1.0 h1:rCUeRUHjBjGTSHl0VC00jUPLz8/F9dDzYI70Hzifhks=
+github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=


### PR DESCRIPTION
- Adds go.mod
- Fixes a typo in test
- When a Go int is requested but TOML float is provided, parses TOML float as int (previously just returns error)